### PR TITLE
Update read-in-files-for-shiny-app.R

### DIFF
--- a/shiny/R/read-in-files-for-shiny-app.R
+++ b/shiny/R/read-in-files-for-shiny-app.R
@@ -76,7 +76,7 @@ read_in_all_files <- function(shiny,
   
   fuzz_join = suppressMessages(read_csv(discourse_naming_joined_file,
                                         col_types = cols())) |> 
-    filter(match == 1 | dist == 0) |> 
+    filter(match == 1 | dist == <0.001) |> 
     select(source:lemma_dis) |> 
     filter(percent >= min_discourse_salience, agreement >= min_naming_agreement) |> 
     select(source, lemma=lemma_naming, stimuli, percent, lemma_dis) |> 


### PR DESCRIPTION
For some reason that I don't quite understand, R converted 0 in the 'dist' column of join_checked_automated.csv to 5.551115e-17 which means that the line that does `filter(match == 1 | dist == 0) got rid of almost all the words that matched between discourse and naming because 5.551115e-17 is not technically 0 🤦‍♂️. 

Rather than figure out why this happened, I just adjusted the filter() function to take very very small values which would be equivalent to 0 as far as the string distance match function goes anyway.